### PR TITLE
Fix: srem

### DIFF
--- a/rq_exporter/patch/worker.py
+++ b/rq_exporter/patch/worker.py
@@ -745,9 +745,6 @@ class Worker(BaseWorker):
 
         if connection is None:
             connection = get_current_connection()
-        if not connection.exists(worker_key):
-            connection.srem(cls.redis_workers_keys, worker_key)
-            return None
 
         name = worker_key[len(prefix) :]
         worker = cls(


### PR DESCRIPTION
Missed removing the block of code needed when switching from monkeypatch to just overwriting the file

This causes the drucker instance to crash periodically